### PR TITLE
Adding $.trim() and Y.Lang.trim() notes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,22 @@ if (foo.size()) {
     <tr>
       <td class="code">
 <pre class="code jq">
+.trim('<i> foo </i>');
+</pre>
+      </td>
+      <td class="code">
+<pre class="code yui">
+Y.Lang.trim('<i> foo </i>');
+</pre>
+      </td>
+      <td class="notes">
+        <p>Stripping leading and trailing whitespace.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td class="code">
+<pre class="code jq">
 .click(<i>fn</i>)
 .focus(<i>fn</i>)
 .blur(<i>fn</i>)


### PR DESCRIPTION
Y.Lang.trim() is extremely well-hidden in the YUI3 documentation; adding it to the Rosetta Stone should make it easier for folks to find out about it.
