### PR TITLE
Fixed explanation of the jQuery listener events

### DIFF
--- a/index.html
+++ b/index.html
@@ -691,8 +691,8 @@ Y.one(Y.config.doc).delegate('click', <i>fn</i>, '#target');
 </pre>
       </td>
       <td class="notes">
-        <p>jQuery's delegate() is generally preferred over on() because of performance as well as chaining limitations (<a href="http://www.alfajango.com/blog/the-difference-between-jquerys-bind-live-and-delegate/">source</a>).</p>
-        <p><code>.live()</code> was deprecated in jQuery 1.7, and removed in jQuery 1.9 in favour of <code>.on()</code></p>
+        <p>jQuery's delegate() is generally preferred over bind() because of performance as well as chaining limitations (<a href="http://www.alfajango.com/blog/the-difference-between-jquerys-bind-live-and-delegate/">source</a>).</p>
+        <p><code>.live()</code> was deprecated in jQuery 1.7, and removed in jQuery 1.9 in favour of <code>.on()</code>. As of jQuery 1.7, <code>.on()</code> is the actual method that bind(), live(), and delegate() passes through. (<a href="http://www.elijahmanor.com/differences-between-jquery-bind-vs-live-vs-delegate-vs-on/">source</a>)</p>
       </td>
     </tr>
 


### PR DESCRIPTION
The description for YUI's "delegate" and "on" needed some tuning up. jQuery highly promotes their ".on()" as the only way to bind elements. Delegate, bind, live are to be there for only the purpose of backward compatibility.  In some ways, I think we should even remove this whole "explanation" and just place a description here like "Binding a listener event to an element with target elements"  or something like that.
